### PR TITLE
🐛 [#117] Fix: 대시보드 디테일 헤더 멤버 표시 문제 수정

### DIFF
--- a/shared/dashboard/components/dashboard-header/detail-header/detail-header-members/detail-header-members.module.css
+++ b/shared/dashboard/components/dashboard-header/detail-header/detail-header-members/detail-header-members.module.css
@@ -18,4 +18,18 @@
 .member {
   color: #fff;
   font-size: 14px;
+  margin-left: -8px;
+}
+
+.member-count {
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  border: 2px solid white;
+  color: #d25b68;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  background-color: #f4d7da;
 }

--- a/shared/dashboard/components/dashboard-header/detail-header/detail-header-members/detail-header-members.tsx
+++ b/shared/dashboard/components/dashboard-header/detail-header/detail-header-members/detail-header-members.tsx
@@ -7,21 +7,34 @@ interface Props {
 }
 
 export default function DetailHeaderMembers(props: Props) {
+  const greaterThanFiveMembers = props.members.length > 5
+  const members = props.members.slice(0, 4)
+  const diff = props.members.length - members.length
+
   return (
     <ul className={classes.members}>
-      {props.members.map((member, index) => (
-        <li
-          key={member.id}
-          className={classes.member}
-          style={{
-            transform: `translateX(-${index * 8}px)`,
-          }}
-        >
-          <Avatar nickname={member.nickname} image={member.profileImageUrl}>
-            <Avatar.Image />
-          </Avatar>
-        </li>
-      ))}
+      {greaterThanFiveMembers ? (
+        <>
+          {props.members.slice(0, 4).map((member, index) => (
+            <li key={member.id} className={classes.member}>
+              <Avatar nickname={member.nickname} image={member.profileImageUrl}>
+                <Avatar.Image />
+              </Avatar>
+            </li>
+          ))}
+          <li key={diff} className={classes.member}>
+            <div className={classes["member-count"]}>+{diff}</div>
+          </li>
+        </>
+      ) : (
+        props.members.map((member, index) => (
+          <li key={member.id} className={classes.member}>
+            <Avatar nickname={member.nickname} image={member.profileImageUrl}>
+              <Avatar.Image />
+            </Avatar>
+          </li>
+        ))
+      )}
     </ul>
   )
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#117 
> ex) #이슈번호, #이슈번호

## 📝작업 내용
- [x] 대시보드 디테일 헤더 멤버 표시 개수 문제.

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?