### PR TITLE
Fix: 테스크 카드 댓글 수정할 때 버그

### DIFF
--- a/features/dashboard/dashboard-task-detail/components/detail-comment/comment-add/task-detail-add-comment.tsx
+++ b/features/dashboard/dashboard-task-detail/components/detail-comment/comment-add/task-detail-add-comment.tsx
@@ -1,4 +1,5 @@
-import TaskDetailCommentForm from "../comment-form/task-detail-comment-form"
+import { TaskDetailCommentForm } from "@features/dashboard/dashboard-task-detail/components"
+import { useCommentCreateForm } from "@features/dashboard/dashboard-task-detail/hooks"
 import classes from "./task-detail-add-comment.module.css"
 
 interface Props {
@@ -7,10 +8,12 @@ interface Props {
 }
 
 export default function TaskDetailAddComment({ cardId, columnId }: Props) {
+  const onSubmit = useCommentCreateForm({ cardId, columnId })
+
   return (
     <div className={classes["comment-form-area"]}>
       <span>댓글</span>
-      <TaskDetailCommentForm cardId={cardId} columnId={columnId} />
+      <TaskDetailCommentForm cardId={cardId} columnId={columnId} onSubmit={onSubmit} />
     </div>
   )
 }

--- a/features/dashboard/dashboard-task-detail/components/detail-comment/comment-form/task-detail-comment-form.tsx
+++ b/features/dashboard/dashboard-task-detail/components/detail-comment/comment-form/task-detail-comment-form.tsx
@@ -3,7 +3,6 @@ import { Button } from "@common/components/ui"
 import { useComposing } from "@common/hooks"
 import { useForm } from "@shared/@common/hooks"
 import type { CommentData } from "@shared/dashboard/types"
-import { useTaskCardCommentForm } from "@features/dashboard/dashboard-task-detail/hooks"
 import { defaultValues, validate } from "@features/dashboard/dashboard-task-detail/logic"
 import { FormControlComment } from "@features/dashboard/dashboard-task-detail/components"
 import classes from "./task-detail-comment-form.module.css"
@@ -11,29 +10,29 @@ import classes from "./task-detail-comment-form.module.css"
 interface Props {
   cardId: number
   columnId: number
+  content?: string
+  onSubmit: (values: CommentData) => Promise<any>
 }
 
-export default function TaskDetailCommentForm({ cardId, columnId }: Props) {
+export default function TaskDetailCommentForm(props: Props) {
   const { isComposing, handleCompositionEnd, handleCompositionStart } = useComposing()
   const { formStates, register, fieldError, handleSubmit } = useForm<CommentData>({
-    defaultValues,
+    defaultValues: defaultValues(props.content),
     validate,
     options: { isFormReset: true },
   })
 
-  const onSubmit = useTaskCardCommentForm({ cardId, columnId })
-
   const handleKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = (event) => {
     if (event.key === "Enter" && !event.shiftKey && !isComposing) {
       event.preventDefault()
-      handleSubmit(onSubmit)(event)
+      handleSubmit(props.onSubmit)(event)
     }
   }
 
   return (
     <form
       className={classes["comment-form"]}
-      onSubmit={handleSubmit(onSubmit)}
+      onSubmit={handleSubmit(props.onSubmit)}
       onCompositionStart={handleCompositionStart}
       onCompositionEnd={handleCompositionEnd}
     >

--- a/features/dashboard/dashboard-task-detail/components/detail-comment/comment-list-item/task-detail-comment-list-item.tsx
+++ b/features/dashboard/dashboard-task-detail/components/detail-comment/comment-list-item/task-detail-comment-list-item.tsx
@@ -7,7 +7,7 @@ import { TaskDetailUpdateCommentForm } from "@features/dashboard/dashboard-task-
 import classes from "./task-detail-comment-list-item.module.css"
 
 export default function TaskDetailCommentListItem(props: Comment) {
-  const { isToggle, onCloseToggle, onOpenToggle } = useToggle()
+  const { isToggle, onCloseToggle: closeUpdateForm, onOpenToggle: openUpdateForm } = useToggle()
 
   const deleteCommentMutation = useDeleteComment(props.cardId, props.id)
   const handleDeleteComment = async () => await deleteCommentMutation.trigger()
@@ -25,13 +25,14 @@ export default function TaskDetailCommentListItem(props: Comment) {
           </time>
         </div>
         {isToggle ? (
-          <TaskDetailUpdateCommentForm {...props} onCloseToggle={onCloseToggle} />
+          <TaskDetailUpdateCommentForm {...props} onCloseToggle={closeUpdateForm} />
         ) : (
           <p className={classes["comment-item__comment"]}>{props.content}</p>
         )}
         <div className={classes["comment-item__utils"]}>
-          <button onClick={onOpenToggle}>수정</button>
+          <button onClick={openUpdateForm}>수정</button>
           <button onClick={handleDeleteComment}>삭제</button>
+          {isToggle && <button onClick={closeUpdateForm}></button>}
         </div>
       </div>
     </li>

--- a/features/dashboard/dashboard-task-detail/components/detail-comment/comment-list-item/task-detail-comment-list-item.tsx
+++ b/features/dashboard/dashboard-task-detail/components/detail-comment/comment-list-item/task-detail-comment-list-item.tsx
@@ -12,6 +12,8 @@ export default function TaskDetailCommentListItem(props: Comment) {
   const deleteCommentMutation = useDeleteComment(props.cardId, props.id)
   const handleDeleteComment = async () => await deleteCommentMutation.trigger()
 
+  console.log(isToggle)
+
   return (
     <li className={classes["comment-list__item"]}>
       <Avatar image={props.author.profileImageUrl} nickname={props.author.nickname}>
@@ -32,7 +34,7 @@ export default function TaskDetailCommentListItem(props: Comment) {
         <div className={classes["comment-item__utils"]}>
           <button onClick={openUpdateForm}>수정</button>
           <button onClick={handleDeleteComment}>삭제</button>
-          {isToggle && <button onClick={closeUpdateForm}></button>}
+          {isToggle && <button onClick={closeUpdateForm}>취소</button>}
         </div>
       </div>
     </li>

--- a/features/dashboard/dashboard-task-detail/components/detail-comment/comment-list-item/task-detail-comment-list-item.tsx
+++ b/features/dashboard/dashboard-task-detail/components/detail-comment/comment-list-item/task-detail-comment-list-item.tsx
@@ -11,9 +11,6 @@ export default function TaskDetailCommentListItem(props: Comment) {
 
   const deleteCommentMutation = useDeleteComment(props.cardId, props.id)
   const handleDeleteComment = async () => await deleteCommentMutation.trigger()
-
-  console.log(isToggle)
-
   return (
     <li className={classes["comment-list__item"]}>
       <Avatar image={props.author.profileImageUrl} nickname={props.author.nickname}>

--- a/features/dashboard/dashboard-task-detail/components/detail-comment/comment-update/task-detail-update-comment.tsx
+++ b/features/dashboard/dashboard-task-detail/components/detail-comment/comment-update/task-detail-update-comment.tsx
@@ -1,5 +1,6 @@
 import type { Comment } from "@shared/dashboard/types"
 import { TaskDetailCommentForm } from "@features/dashboard/dashboard-task-detail/components"
+import { useCommentUpdateForm } from "@features/dashboard/dashboard-task-detail/hooks"
 import classes from "./task-detail-update-comment.module.css"
 
 interface Props extends Pick<Comment, "content" | "cardId" | "id"> {
@@ -7,9 +8,14 @@ interface Props extends Pick<Comment, "content" | "cardId" | "id"> {
 }
 
 export default function TaskDetailUpdateCommentForm(props: Props) {
+  const onSubmit = useCommentUpdateForm({
+    cardId: props.cardId,
+    commentId: props.id,
+    onCloseToggle: props.onCloseToggle,
+  })
   return (
     <div className={classes["update-form"]}>
-      <TaskDetailCommentForm cardId={props.cardId} columnId={props.id} />
+      <TaskDetailCommentForm cardId={props.cardId} columnId={props.id} content={props.content} onSubmit={onSubmit} />
     </div>
   )
 }

--- a/features/dashboard/dashboard-task-detail/hooks/index.ts
+++ b/features/dashboard/dashboard-task-detail/hooks/index.ts
@@ -1,3 +1,4 @@
-import useTaskCardCommentForm from "./use-task-card-comment-form"
+import useCommentCreateForm from "./use-comment-create-form"
+import useCommentUpdateForm from "./use-comment-update-form"
 
-export { useTaskCardCommentForm }
+export { useCommentCreateForm, useCommentUpdateForm }

--- a/features/dashboard/dashboard-task-detail/hooks/use-comment-create-form.tsx
+++ b/features/dashboard/dashboard-task-detail/hooks/use-comment-create-form.tsx
@@ -7,7 +7,7 @@ interface Props {
   columnId: number
 }
 
-export default function useTaskCardCommentForm(props: Props) {
+export default function useCommentCreateForm(props: Props) {
   const dashboardId = +useRouterQuery("id")
   const createCommentMutation = useCreateComment(props.cardId)
 

--- a/features/dashboard/dashboard-task-detail/hooks/use-comment-update-form.tsx
+++ b/features/dashboard/dashboard-task-detail/hooks/use-comment-update-form.tsx
@@ -1,0 +1,17 @@
+import { CommentData } from "@shared/dashboard/types"
+import { useUpdateComment } from "@shared/dashboard/hooks"
+
+interface Props {
+  cardId: number
+  commentId: number
+  onCloseToggle: () => void
+}
+
+export default function useCommentUpdateForm(props: Props) {
+  const createCommentMutation = useUpdateComment(props.cardId, props.commentId)
+  const onSubmit = async (values: CommentData) => {
+    await createCommentMutation.trigger({ content: values.content })
+    props.onCloseToggle()
+  }
+  return onSubmit
+}

--- a/features/dashboard/dashboard-task-detail/logic/task-detail-comment-form.logic.ts
+++ b/features/dashboard/dashboard-task-detail/logic/task-detail-comment-form.logic.ts
@@ -1,9 +1,9 @@
 import type { CommentData } from "@shared/dashboard/types"
 import { taskCardCommentValidation } from "@features/dashboard/dashboard-task-detail/utils"
 
-export const defaultValues: CommentData = {
-  content: "",
-}
+export const defaultValues = (content?: string): CommentData => ({
+  content: content ? content : "",
+})
 
 export const validate = (values: CommentData) => {
   const error: { [key in keyof CommentData]?: string } = {}


### PR DESCRIPTION
## #️⃣연관된 이슈
#124 
> ex) #이슈번호, #이슈번호

## 📝작업 내용
- [x] 재사용성을 위해 폼 리팩토링 (파일 네이밍 변경 및 props로 onSubmit 받아오기)
- [x] useCommentUpdateForm 훅 추가
- [x] 댓글 수정 후 모달 닫히도록 구현.

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?