### PR TITLE
🐛 Fix: 어드민에서 구성원 삭제 안되는 에러

### DIFF
--- a/features/dashboard/dashboard-members/components/member-list-item/dashboard-member-list-item.tsx
+++ b/features/dashboard/dashboard-members/components/member-list-item/dashboard-member-list-item.tsx
@@ -6,16 +6,17 @@ import classes from "./dashboard-member-list-item.module.css"
 
 interface Props extends Member {
   dashboardUserId: number
+  isCreatedDashboardUser: boolean
 }
 
 export default function DashboardMemberListItem(props: Props) {
   const dashboardId = +useRouterQuery("id")
   const currentPage = useMemberPageStore.use.currentPage()
   const deleteMemberMutation = useDeleteMember(dashboardId, currentPage, props.id)
-  const isCreatedDashboardUser = props.userId === props.dashboardUserId
+  const isAdmin = props.userId === props.dashboardUserId
 
   const handleDeleteMember = async () => {
-    if (isCreatedDashboardUser) return
+    if (isAdmin) return
     await deleteMemberMutation.trigger()
   }
 
@@ -27,16 +28,16 @@ export default function DashboardMemberListItem(props: Props) {
           <Avatar.Name />
         </Avatar>
       </div>
-      {isCreatedDashboardUser && (
+      {props.isCreatedDashboardUser && (
         <div>
           <Button
             buttonStyle="secondary"
             size="small"
             isLoading={deleteMemberMutation.isMutating}
-            disabled={isCreatedDashboardUser}
+            disabled={isAdmin}
             onClick={handleDeleteMember}
           >
-            {isCreatedDashboardUser ? "방장" : "삭제"}
+            {isAdmin ? "방장" : "삭제"}
           </Button>
         </div>
       )}

--- a/features/dashboard/dashboard-members/components/member-list/dashboard-member-list.tsx
+++ b/features/dashboard/dashboard-members/components/member-list/dashboard-member-list.tsx
@@ -1,4 +1,4 @@
-import { useRouterQuery } from "@common/hooks"
+import { useAuthStore, useRouterQuery } from "@common/hooks"
 import { useFetchMembers, useMemberPageStore } from "@shared/dashboard/hooks"
 import { DashboardMemberListItem } from "@features/dashboard/dashboard-members/components"
 import type { Dashboard } from "@shared/dashboard/types"
@@ -12,12 +12,18 @@ export default function DashboardMemberList(props: Props) {
   const dashboardId = useRouterQuery("id")
   const currentPage = useMemberPageStore.use.currentPage()
   const memberQuery = useFetchMembers(+dashboardId, currentPage)
+  const myUserId = useAuthStore.use.id()
+  const isCreatedDashboardUser = props.dashboard.userId === myUserId
 
   return (
     <ul className={classes.list}>
       {memberQuery.data?.members.map((member) => (
         <li className={classes["list-item"]} key={member.id}>
-          <DashboardMemberListItem {...member} dashboardUserId={props.dashboard.userId} />
+          <DashboardMemberListItem
+            {...member}
+            dashboardUserId={props.dashboard.userId}
+            isCreatedDashboardUser={isCreatedDashboardUser}
+          />
         </li>
       ))}
     </ul>


### PR DESCRIPTION
## #️⃣연관된 이슈
#183 
> ex) #이슈번호, #이슈번호

## 📝작업 내용
어드민에서 구성원 삭제 안되는 에러 발생.

=> 대시보드를 만든 유저아이디가 로그인한 유저아이디와 비교해서 처리.

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?