### PR TITLE
🐛 Fix: 테스크카드 업데이트시 담당자 자동선택 안되는 문제

### DIFF
--- a/features/dashboard/dashboard-task-card/components/task-card-form-control/form-control-manager.tsx
+++ b/features/dashboard/dashboard-task-card/components/task-card-form-control/form-control-manager.tsx
@@ -7,10 +7,14 @@ interface Props {
   hasError: (field: string) => string
   members: Member[]
   className?: string
+  isAssigneeUserId?: number
 }
 
 export default function FormControlManager({ members, onChange, hasError, ...props }: Props) {
-  const [selectedMember, setSelectedMember] = useState<Member>(members[0])
+  const existingMember = props.isAssigneeUserId
+    ? members.find((member) => member.userId === props.isAssigneeUserId) || members[0]
+    : members[0]
+  const [selectedMember, setSelectedMember] = useState<Member>(existingMember)
   const handleSelectedManager = (member: Member) => {
     setSelectedMember(member)
     onChange(member.userId)

--- a/features/dashboard/dashboard-task-card/components/task-card-modal/dashboard-task-card-update-modal.tsx
+++ b/features/dashboard/dashboard-task-card/components/task-card-modal/dashboard-task-card-update-modal.tsx
@@ -64,6 +64,7 @@ export default function DashboardTaskCardUpdateModal(props: TaskCardModalProps) 
             hasError={fieldError}
             members={members}
             className={classes.dropdown}
+            isAssigneeUserId={formStates.formValues.assigneeUserId}
           />
         </div>
         <FormControlTitle register={register} hasError={fieldError} />


### PR DESCRIPTION
## #️⃣연관된 이슈
#185 
> ex) #이슈번호, #이슈번호

## 📝작업 내용
테스크카드 업데이트시 담당자 자동선택 안되는 문제.

=> 업데이트시 userId를 전달해 자동으로 값이 바인딩되도록 해결.

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?