### PR TITLE
🐛 Fix: 대시보드 초대내역 페이지네이션 에러

### DIFF
--- a/features/dashboard/dashboard-invite/components/invite-list-item/dashboard-invite-list-item.module.css
+++ b/features/dashboard/dashboard-invite/components/invite-list-item/dashboard-invite-list-item.module.css
@@ -3,3 +3,7 @@
   justify-content: space-between;
   align-items: center;
 }
+
+.list-padding {
+  padding: 10px 0;
+}

--- a/features/dashboard/dashboard-invite/components/invite-pagination/invite-pagination.tsx
+++ b/features/dashboard/dashboard-invite/components/invite-pagination/invite-pagination.tsx
@@ -2,10 +2,14 @@ import { Pagination } from "@common/components/ui"
 import { useFetchInvitation, useInvitePageStore } from "@shared/dashboard/hooks"
 import { INVITE_POST_COUNT } from "@features/dashboard/dashboard-invite/constants"
 
-export default function InvitePagination() {
+interface Props {
+  isPermission: boolean
+}
+
+export default function InvitePagination(props: Props) {
   const currentPage = useInvitePageStore.use.currentPage()
   const setCurrentPage = useInvitePageStore.use.setCurrentPage()
-  const invitationQuery = useFetchInvitation(currentPage)
+  const invitationQuery = useFetchInvitation(currentPage, true)
   const maxPage = Math.ceil((invitationQuery.data?.totalCount || 1) / INVITE_POST_COUNT)
 
   return (

--- a/features/dashboard/dashboard-invite/components/invite/dashboard-invite.tsx
+++ b/features/dashboard/dashboard-invite/components/invite/dashboard-invite.tsx
@@ -29,7 +29,7 @@ export default function DashboardInvite(props: Props) {
           <DashboardInviteList isPermission={isInvitationPermission} />
         </Suspensive>
       }
-      renderPagination={<InvitePagination />}
+      renderPagination={<InvitePagination isPermission={isInvitationPermission} />}
       renderInviteButton={<DashboardInviteButton />}
     />
   )

--- a/shared/dashboard/hooks/mutation/dashboard.mutation.ts
+++ b/shared/dashboard/hooks/mutation/dashboard.mutation.ts
@@ -49,7 +49,7 @@ export function useDeleteDashboard(dashboardId: number, currentPage: number) {
 
 export function useInvite(currentPage: number) {
   const dashboardId = useRouterQuery("id")
-  const { mutate, error } = useFetchInvitation(currentPage)
+  const { mutate, error } = useFetchInvitation(currentPage, true)
 
   return useSWRMutation(`dashboards/${dashboardId}/invitations`, DashboardApiInstance.dashboardInvite, {
     onError(err, key, config) {
@@ -64,7 +64,7 @@ export function useInvite(currentPage: number) {
 
 export function useDeleteInvitation(currentPage: number, invitationId: number) {
   const dashboardId = useRouterQuery("id")
-  const { mutate, data: invitationData } = useFetchInvitation(currentPage)
+  const { mutate, data: invitationData } = useFetchInvitation(currentPage, true)
   const currentPagination = useInvitePageStore.use.currentPage()
   const setCurrentPage = useInvitePageStore.use.setCurrentPage()
 
@@ -73,7 +73,7 @@ export function useDeleteInvitation(currentPage: number, invitationId: number) {
     DashboardApiInstance.deleteInvitation,
     {
       onError(err, key, config) {
-        console.log("Mutation Error", Error)
+        console.log(Error)
       },
 
       onSuccess(data, key) {


### PR DESCRIPTION
## #️⃣연관된 이슈
#187 
> ex) #이슈번호, #이슈번호

## 📝작업 내용
대시보드 초대내역 페이지네이션 에러

=> 추가 및 삭제시 페이지네이션이 올바르게 작동하지 않는 문제를 캐시 무효화를 사용해서 해결
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?